### PR TITLE
fix: preserve Long precision in query results

### DIFF
--- a/src/adapters/goldendb.ts
+++ b/src/adapters/goldendb.ts
@@ -74,6 +74,7 @@ export class GoldenDBAdapter implements DbAdapter {
         password: this.config.password,
         database: this.config.database,
         multipleStatements: false,
+        supportBigNumbers: true,
         waitForConnections: true,
         connectionLimit: 3,
         maxIdle: 1,

--- a/src/adapters/mongodb.ts
+++ b/src/adapters/mongodb.ts
@@ -309,29 +309,32 @@ export class MongoDBAdapter implements DbAdapter {
   }
 
   /**
-   * 格式化 MongoDB 文档（将 ObjectId 转换为字符串）
+   * 格式化 MongoDB 文档（将 ObjectId/Long 等 BSON 类型转换为字符串）
    */
   private formatDocument(doc: Document): Document {
     const formatted: Document = {};
 
     for (const [key, value] of Object.entries(doc)) {
-      if (value && typeof value === 'object' && '_bsontype' in value) {
-        // 处理 BSON 类型（如 ObjectId）
-        formatted[key] = value.toString();
-      } else if (value && typeof value === 'object' && !Array.isArray(value)) {
-        // 递归处理嵌套对象
-        formatted[key] = this.formatDocument(value);
-      } else if (Array.isArray(value)) {
-        // 处理数组
-        formatted[key] = value.map(item =>
-          item && typeof item === 'object' ? this.formatDocument(item) : item
-        );
-      } else {
-        formatted[key] = value;
-      }
+      formatted[key] = this.formatValue(value);
     }
 
     return formatted;
+  }
+
+  private formatValue(value: unknown): unknown {
+    if (value && typeof value === 'object' && '_bsontype' in value) {
+      return value.toString();
+    }
+
+    if (Array.isArray(value)) {
+      return value.map(item => this.formatValue(item));
+    }
+
+    if (value && typeof value === 'object') {
+      return this.formatDocument(value as Document);
+    }
+
+    return value;
   }
 
   /**

--- a/src/adapters/mysql.ts
+++ b/src/adapters/mysql.ts
@@ -73,6 +73,7 @@ export class MySQLAdapter implements DbAdapter {
         password: this.config.password,
         database: this.config.database,
         multipleStatements: false,
+        supportBigNumbers: true,
         // 连接池配置
         waitForConnections: true,
         connectionLimit: 3,

--- a/src/adapters/oceanbase.ts
+++ b/src/adapters/oceanbase.ts
@@ -74,6 +74,7 @@ export class OceanBaseAdapter implements DbAdapter {
         password: this.config.password,
         database: this.config.database,
         multipleStatements: false,
+        supportBigNumbers: true,
         waitForConnections: true,
         connectionLimit: 3,
         maxIdle: 1,

--- a/src/adapters/polardb.ts
+++ b/src/adapters/polardb.ts
@@ -74,6 +74,7 @@ export class PolarDBAdapter implements DbAdapter {
         password: this.config.password,
         database: this.config.database,
         multipleStatements: false,
+        supportBigNumbers: true,
         waitForConnections: true,
         connectionLimit: 3,
         maxIdle: 1,

--- a/src/adapters/tidb.ts
+++ b/src/adapters/tidb.ts
@@ -74,6 +74,7 @@ export class TiDBAdapter implements DbAdapter {
         password: this.config.password,
         database: this.config.database,
         multipleStatements: false,
+        supportBigNumbers: true,
         waitForConnections: true,
         connectionLimit: 3,
         maxIdle: 1,

--- a/src/core/database-service.ts
+++ b/src/core/database-service.ts
@@ -92,7 +92,60 @@ export class DatabaseService {
     // Execute query
     const result = await this.adapter.executeQuery(query, params);
 
-    return result;
+    return this.normalizeQueryResult(result);
+  }
+
+  /**
+   * 归一化查询结果中的大整数/BSON Long，避免在 JSON 输出时丢失精度
+   */
+  private normalizeQueryResult(result: QueryResult): QueryResult {
+    return {
+      ...result,
+      rows: this.normalizeForJson(result.rows) as Record<string, unknown>[],
+      metadata: result.metadata
+        ? this.normalizeForJson(result.metadata) as Record<string, unknown>
+        : undefined,
+    };
+  }
+
+  /**
+   * 递归归一化值，确保可以安全输出为 JSON
+   */
+  private normalizeForJson(value: unknown): unknown {
+    if (typeof value === 'bigint') {
+      return value.toString();
+    }
+
+    if (value === null || value === undefined) {
+      return value;
+    }
+
+    if (
+      value instanceof Date ||
+      value instanceof RegExp ||
+      ArrayBuffer.isView(value) ||
+      value instanceof ArrayBuffer
+    ) {
+      return value;
+    }
+
+    if (Array.isArray(value)) {
+      return value.map(item => this.normalizeForJson(item));
+    }
+
+    if (typeof value === 'object') {
+      if ('_bsontype' in value && typeof value.toString === 'function') {
+        return value.toString();
+      }
+
+      const normalized: Record<string, unknown> = {};
+      for (const [key, nestedValue] of Object.entries(value)) {
+        normalized[key] = this.normalizeForJson(nestedValue);
+      }
+      return normalized;
+    }
+
+    return value;
   }
 
   /**
@@ -367,10 +420,11 @@ export class DatabaseService {
 
     // 4. 执行查询
     const result = await this.adapter.executeQuery(query);
+    const normalizedRows = this.normalizeForJson(result.rows) as Record<string, unknown>[];
 
     // 5. 处理结果
-    const hasMore = result.rows.length > safeLimit;
-    const rows = hasMore ? result.rows.slice(0, safeLimit) : result.rows;
+    const hasMore = normalizedRows.length > safeLimit;
+    const rows = hasMore ? normalizedRows.slice(0, safeLimit) : normalizedRows;
 
     const values = rows.map(row => row.value as string | number | null);
     const valueCounts = includeCount
@@ -443,9 +497,10 @@ export class DatabaseService {
 
     // 5. 执行查询
     const result = await this.adapter.executeQuery(query);
+    const normalizedRows = this.normalizeForJson(result.rows) as Record<string, unknown>[];
 
     // 6. 脱敏处理
-    const { maskedRows, maskedColumns } = this.dataMasker.maskRows(result.rows);
+    const { maskedRows, maskedColumns } = this.dataMasker.maskRows(normalizedRows);
 
     return {
       tableName: actualTableName,

--- a/tests/unit/database-service.test.ts
+++ b/tests/unit/database-service.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi } from 'vitest';
+import { DatabaseService } from '../../src/core/database-service.js';
+import type { DbAdapter, DbConfig, QueryResult, SchemaInfo } from '../../src/types/adapter.js';
+
+function createAdapterStub(queryResult: QueryResult, schema?: SchemaInfo): DbAdapter {
+  return {
+    connect: vi.fn(async () => {}),
+    disconnect: vi.fn(async () => {}),
+    executeQuery: vi.fn(async () => queryResult),
+    getSchema: vi.fn(async () => schema ?? {
+      databaseType: 'mysql',
+      databaseName: 'test',
+      tables: [
+        {
+          name: 'users',
+          columns: [
+            { name: 'id', type: 'bigint', nullable: false },
+            { name: 'metadata', type: 'json', nullable: true },
+          ],
+          primaryKeys: ['id'],
+        },
+      ],
+    }),
+    isWriteOperation: vi.fn(() => false),
+  };
+}
+
+describe('DatabaseService', () => {
+  const config: DbConfig = {
+    type: 'mysql',
+    host: 'localhost',
+    port: 3306,
+  };
+
+  it('should normalize bigint and BSON Long-like values in executeQuery results', async () => {
+    const bsonLongLike = {
+      _bsontype: 'Long',
+      toString: () => '9223372036854775807',
+    };
+
+    const service = new DatabaseService(createAdapterStub({
+      rows: [
+        {
+          id: 9007199254740993n,
+          mongoLong: bsonLongLike,
+          nested: {
+            longValue: bsonLongLike,
+            bigintValue: 42n,
+          },
+          list: [9007199254740995n, bsonLongLike, { deep: 7n }],
+        },
+      ],
+      metadata: {
+        insertId: 9007199254740994n,
+      },
+    }), config);
+
+    const result = await service.executeQuery('SELECT * FROM users');
+
+    expect(result).toEqual({
+      rows: [
+        {
+          id: '9007199254740993',
+          mongoLong: '9223372036854775807',
+          nested: {
+            longValue: '9223372036854775807',
+            bigintValue: '42',
+          },
+          list: ['9007199254740995', '9223372036854775807', { deep: '7' }],
+        },
+      ],
+      metadata: {
+        insertId: '9007199254740994',
+      },
+    });
+  });
+
+  it('should normalize enum values before returning', async () => {
+    const bsonLongLike = {
+      _bsontype: 'Long',
+      toString: () => '9223372036854775807',
+    };
+
+    const service = new DatabaseService(createAdapterStub({
+      rows: [
+        { value: bsonLongLike },
+        { value: 9007199254740993n },
+      ],
+    }), config);
+
+    const result = await service.getEnumValues('users', 'id');
+
+    expect(result.values).toEqual(['9223372036854775807', '9007199254740993']);
+  });
+
+  it('should normalize sample data before masking', async () => {
+    const service = new DatabaseService(createAdapterStub({
+      rows: [
+        {
+          id: -9007199254740993n,
+          metadata: {
+            longValue: -9007199254740995n,
+          },
+        },
+      ],
+    }), config);
+
+    const result = await service.getSampleData('users', ['id', 'metadata']);
+
+    expect(result.rows).toEqual([
+      {
+        id: '-9007199254740993',
+        metadata: {
+          longValue: '-9007199254740995',
+        },
+      },
+    ]);
+  });
+});

--- a/tests/unit/mongodb-adapter.test.ts
+++ b/tests/unit/mongodb-adapter.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { MongoDBAdapter } from '../../src/adapters/mongodb.js';
+
+describe('MongoDBAdapter', () => {
+  it('should format BSON Long values in nested arrays and objects', () => {
+    const adapter = new MongoDBAdapter({
+      host: 'localhost',
+      port: 27017,
+      database: 'test',
+    });
+
+    const bsonLongLike = {
+      _bsontype: 'Long',
+      toString: () => '9223372036854775807',
+    };
+
+    const formatted = (adapter as any).formatDocument({
+      topLevel: bsonLongLike,
+      nested: {
+        value: bsonLongLike,
+      },
+      list: [bsonLongLike, { value: bsonLongLike }, 'ok'],
+    });
+
+    expect(formatted).toEqual({
+      topLevel: '9223372036854775807',
+      nested: {
+        value: '9223372036854775807',
+      },
+      list: ['9223372036854775807', { value: '9223372036854775807' }, 'ok'],
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- enable `supportBigNumbers` for MySQL-family adapters so 64-bit integer values are not truncated before they reach the MCP response layer
- normalize `bigint` and BSON `Long` values in `DatabaseService` and the MongoDB adapter before JSON serialization
- add unit coverage for `executeQuery`, `getEnumValues`, `getSampleData`, and nested MongoDB Long formatting

## Test plan
- [x] `npm run build`
- [x] `npm run test:unit`
- [x] manually verified the local MCP server returns Long values without precision loss