### PR TITLE
fix(dm): 修复连接不上达梦数据库的问题

### DIFF
--- a/src/adapters/dm.ts
+++ b/src/adapters/dm.ts
@@ -43,6 +43,25 @@ async function loadDMDB() {
   }
 }
 
+export function buildDMConnectionConfig(config: {
+  host: string;
+  port: number;
+  user?: string;
+  password?: string;
+  database?: string;
+}): Record<string, unknown> {
+  return {
+    connectString: `${config.host}:${config.port || 5236}`,
+    user: config.user,
+    password: config.password,
+    // DM 的 schema 与用户名命名空间一致，优先使用 database 作为 schema
+    schema: config.database,
+    // 禁用消息加密以避免 OpenSSL 3.0 兼容性问题
+    cipherPath: '',
+    loginEncrypt: false,
+  };
+}
+
 export class DMAdapter implements DbAdapter {
   private connection: any = null;
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
@@ -109,19 +128,7 @@ export class DMAdapter implements DbAdapter {
   async connect(): Promise<void> {
     try {
       const DM = await loadDMDB();
-
-      // 达梦数据库连接配置
-      const connectionConfig = {
-        host: this.config.host,
-        port: this.config.port || 5236, // 达梦默认端口
-        user: this.config.user,
-        password: this.config.password,
-        database: this.config.database,
-        // 禁用消息加密以避免 OpenSSL 3.0 兼容性问题
-        // 如果需要加密连接，请确保达梦数据库服务器配置了兼容的加密算法
-        cipherPath: '',
-        loginEncrypt: false,
-      };
+      const connectionConfig = buildDMConnectionConfig(this.config);
 
       this.connection = await DM.getConnection(connectionConfig);
       this.connectionConfig = connectionConfig;

--- a/tests/unit/dm-adapter.test.ts
+++ b/tests/unit/dm-adapter.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { buildDMConnectionConfig } from '../../src/adapters/dm';
+
+describe('DMAdapter connection config', () => {
+  it('should prefer connectString over host/port object fields', () => {
+    const config = buildDMConnectionConfig({
+      host: '192.168.99.172',
+      port: 5236,
+      user: 'SYSDBA',
+      password: 'SYSDBA001',
+      database: 'CASE_COMMAND_GZ',
+    });
+
+    expect(config.connectString).toBe('192.168.99.172:5236');
+    expect(config.user).toBe('SYSDBA');
+    expect(config.password).toBe('SYSDBA001');
+    expect(config.schema).toBe('CASE_COMMAND_GZ');
+    expect(config.loginEncrypt).toBe(false);
+    expect(config.cipherPath).toBe('');
+    expect(config.host).toBeUndefined();
+    expect(config.port).toBeUndefined();
+  });
+
+  it('should use default DM port when port is not provided', () => {
+    const config = buildDMConnectionConfig({
+      host: 'db.example.com',
+      port: undefined as unknown as number,
+      user: 'u',
+      password: 'p',
+    });
+
+    expect(config.connectString).toBe('db.example.com:5236');
+  });
+});


### PR DESCRIPTION
switch DM adapter to build connection config with connectString to avoid host/port parsing issues in dmdb.

add unit tests to lock config shape and default DM port behavior.